### PR TITLE
Restore package name back to RationalMath

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "decimal_math"
+name = "RationalMath"
 version = "0.0.1"
 
 [dependencies]


### PR DESCRIPTION
All packages that depend on this package have to match the package name.