### PR TITLE
Lock aptos-core to version 1.0.3

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -3,7 +3,7 @@ name = "rationalmath"
 version = "0.1.0"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "devnet" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "aptos-cli-v1.0.3" }
 
 [addresses]
 rationalmath = "_"


### PR DESCRIPTION
Depending on a development branch makes the build less hermetic. For example: a recent change in the devnet branch removed support for inline functions.